### PR TITLE
fix admin breadcrumb link

### DIFF
--- a/includes/class-checklists-detail.php
+++ b/includes/class-checklists-detail.php
@@ -20,8 +20,14 @@ class Gravity_Flow_Checklists_Detail {
 			return;
 		}
 
-		$list_url = remove_query_arg( array( 'checklist', 'id', 'gf_token', 'lid', 'view', 'page' ) );
 		if ( $args['breadcrumbs'] ) {
+
+			$query_args = array( 'checklist', 'id', 'gf_token', 'lid', 'view' );
+			if ( ! is_admin() ) {
+				$query_args[] = 'page';
+			}
+			$list_url = remove_query_arg( $query_args );
+
 		?>
 		<h2>
 			<?php


### PR DESCRIPTION
Fixes the breadcrumb link on the admin checklist detail page which currently redirects to a blank `/wp-admin/admin.php` page due to the `page=gravityflow-checklists` query arg being removed.