### PR TITLE
Fix form completing when partial entry saved

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed the form being marked as complete when a partial entry is saved.

--- a/includes/class-checklist-personal.php
+++ b/includes/class-checklist-personal.php
@@ -49,6 +49,11 @@ class Gravity_Flow_Checklist_Personal extends Gravity_Flow_Checklist {
 					'value'    => $this->user->ID,
 					'operator' => '=',
 				),
+				array(
+					'key'      => 'partial_entry_id',
+					'operator' => 'is',
+					'value'    => ''
+				)
 			),
 		);
 


### PR DESCRIPTION
re: [HS#8760](https://secure.helpscout.net/conversation/822138983/8760?folderId=1113535)

Updates Gravity_Flow_Checklist_Personal::get_entries() to only return complete entries.

## Testing Instructions
- Enable Partial Entries for a form which is assigned to a checklist
- Preview form and enter a value in one field, allow partial entry to be saved
- In another window view the checklist and find the form is marked as complete
- With this branch find the form is no longer marked as complete